### PR TITLE
Fix inconsistent indents for gradle in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ When I start to make this library, I set some goals:
 
 ```groovy
 dependencies {
-	compile 'com.android.support:recyclerview-v7:21.0.0'
-        compile 'com.android.support:support-v4:20.+'
-        compile "com.daimajia.swipelayout:library:1.1.8@aar"
+    compile 'com.android.support:recyclerview-v7:21.0.0'
+    compile 'com.android.support:support-v4:20.+'
+    compile "com.daimajia.swipelayout:library:1.1.8@aar"
 }
 ```
 


### PR DESCRIPTION
Previously tab and whitespaces are mixed.
